### PR TITLE
Calendar Versioning に変更する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 # 変更履歴
 
-nablarch-fw-batch-parallelizable-example に関する注目すべき変更はこのファイルで文書化されます。
+nablarch-fw-batch-parallelizable-example に関する注目すべき変更はこのファイルで文書化されます。  
+[Calendar Versioning — CalVer](https://calver.org/) `YYYY.MM.MICRO` を採用しています。
 
 このファイルの書き方に関する推奨事項については、[Keep a Changelog](https://keepachangelog.com/ja/1.0.0/) を確認してください。
 
 ## Unreleased
+
+### Changed
+- Calender Versioning に変更しました [PR#3](https://github.com/lerna-stack/nablarch-fw-batch-parallelizable-example/pull/3)  
+
 ### Dependency Updates
 - Update *[nablarch-fw-batch-parallelizable]*
   to [1.2.1](https://github.com/lerna-stack/nablarch-fw-batch-parallelizable/releases/tag/v1.2.1)
@@ -12,8 +17,9 @@ nablarch-fw-batch-parallelizable-example に関する注目すべき変更はこ
   ([PR#2](https://github.com/lerna-stack/nablarch-fw-batch-parallelizable-example/pull/2),
    [PR#4](https://github.com/lerna-stack/nablarch-fw-batch-parallelizable-example/pull/4))
 
-## [v1.2.0] - 2021-3-26
+## [v1.2.0] ([v2021.3.0]) - 2021-3-26
 [v1.2.0]: https://github.com/lerna-stack/nablarch-fw-batch-parallelizable-example/releases/tag/v1.2.0
+[v2021.3.0]: https://github.com/lerna-stack/nablarch-fw-batch-parallelizable-example/releases/tag/v2021.3.0
 
 - Initial release
 


### PR DESCRIPTION
他サンプルプロジェクトと同様の Calendar Versioning に変更します。
他サンプルプロジェクトのリリースは次の URL から確認できます。
* [Releases · lerna-stack/lerna-sample-account-app](https://github.com/lerna-stack/lerna-sample-account-app/releases)
* [Releases · lerna-stack/lerna-sample-payment-app](https://github.com/lerna-stack/lerna-sample-payment-app/releases)

#### TODO
* [x] マージ待ち (https://github.com/lerna-stack/nablarch-fw-batch-parallelizable-example/pull/2)
* [x] マージ待ち (https://github.com/lerna-stack/nablarch-fw-batch-parallelizable-example/pull/4)
* [x] タグ v2021.3.0 を作成する (v1.2.0 と同じコミットから作成する)
* ~~タグ v1.2.0 を削除する~~
  タグ v.1.2.0 はそのまま残しておきます。