### PR TITLE
Release v2021.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ nablarch-fw-batch-parallelizable-example に関する注目すべき変更はこ
 
 ## Unreleased
 
+
+## [v2021.9.0] - 2021-9-30
+[v2021.9.0]: https://github.com/lerna-stack/nablarch-fw-batch-parallelizable-example/compare/v2021.3.0...v2021.9.0
+
 ### Changed
 - Calender Versioning に変更しました [PR#3](https://github.com/lerna-stack/nablarch-fw-batch-parallelizable-example/pull/3)  
 

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ mvn package
 ```
 
 ビルドされるファイルは次のようなファイルです。
-- `target/application-1.2.0.zip`
-- `target/nablarch-fw-batch-parallelizable-example-1.2.0.jar`
+- `target/application-2021.9.0.zip`
+- `target/nablarch-fw-batch-parallelizable-example-2021.9.0.jar`
 - etc...
 
 
@@ -93,13 +93,13 @@ mvn exec:java -Dexec.mainClass=nablarch.fw.launcher.Main -Dexec.args="'-requestP
 `maven-assembly-plugin` を使用して実行可能 jar の生成を行っているため、
 *データバインドを使用した住所登録バッチ* は次の手順でも実行できます。
 
-1. `target/application-1.2.0.zip` を `target` ディレクトリに解凍します。  
+1. `target/application-2021.9.0.zip` を `target` ディレクトリに解凍します。  
    ```shell
-   unzip -o target/application-1.2.0.zip -d target/
+   unzip -o target/application-2021.9.0.zip -d target/
    ```
 1. `jar` からバッチを起動します。
     ```shell
-    java -Dexec.mainClass=nablarch.fw.launcher.Main -jar target/nablarch-fw-batch-parallelizable-example-1.2.0.jar '-requestPath' 'ImportZipCodeFileAction/ImportZipCodeFile' '-diConfig' 'classpath:import-zip-code-file.xml' '-userId' '105'
+    java -Dexec.mainClass=nablarch.fw.launcher.Main -jar target/nablarch-fw-batch-parallelizable-example-2021.9.0.jar '-requestPath' 'ImportZipCodeFileAction/ImportZipCodeFile' '-diConfig' 'classpath:import-zip-code-file.xml' '-userId' '105'
     ```
 
 ### データベースを確認する

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   -->
   <groupId>com.lerna-stack</groupId>
   <artifactId>nablarch-fw-batch-parallelizable-example</artifactId>
-  <version>1.2.0</version>
+  <version>2021.9.0</version>
   <packaging>jar</packaging>
 
   <properties>


### PR DESCRIPTION
v2021.9.0 をリリースします。
このバージョンからは Calendar Versioning へに変更になります。

## TODO
* [x] 動作確認 (README に記載してある手順を試します)

## TODO (本PRマージ後)
* [x] main ブランチから v2021.9.0 のリリース(タグ)を作成します